### PR TITLE
Support Froala Editor (wysiwyg-rails) 3.x too

### DIFF
--- a/wysiwyg-editor-ruby-sdk.gemspec
+++ b/wysiwyg-editor-ruby-sdk.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |gem|
   gem.version       = FroalaEditorSDK::Version::String
 
   gem.add_dependency 'mime-types', '~> 3.1'
-  gem.add_dependency 'wysiwyg-rails', '~> 2.9'
+  gem.add_dependency 'wysiwyg-rails', '>= 2.9', '< 4.0'
   gem.add_dependency 'mini_magick', '~> 4.5'
 end


### PR DESCRIPTION
Only loosening the lock works for everything we are using (which is FroalaEditorSDK::S3). Not sure if the rest of this gem also works with Froala 3, maybe somebody could verify that before merge.

If I need to update the (Tiny) version in version.rb please let me know.