### PR TITLE
Release automation dispatch event

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,4 @@
-name: Auto Release – Ruby SDK (Child-B)
+name: Auto Release – Ruby SDK
 
 on:
   pull_request:
@@ -45,25 +45,12 @@ jobs:
 
       - name: Read version from gemspec
         run: |
-          VERSION=$(ruby -e "spec = Gem::Specification.load('wysiwyg-editor-ruby-sdk.gemspec'); puts spec.version")
+          VERSION=$(ruby -e "
+            spec = Gem::Specification.load('wysiwyg-editor-ruby-sdk.gemspec')
+            puts spec.version
+          ")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1'
-
-      - name: Build gem
-        run: gem build wysiwyg-editor-ruby-sdk.gemspec
-
-      - name: Publish to RubyGems
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: |
-          mkdir -p ~/.gem
-          echo ":rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
-          chmod 600 ~/.gem/credentials
-          gem push froala-editor-sdk-${VERSION}.gem
+          echo "Releasing version: $VERSION"
 
       - name: Create GitHub Release
         env:
@@ -73,4 +60,7 @@ jobs:
             echo "Release v${VERSION} already exists. Skipping."
             exit 0
           fi
-          gh release create "v${VERSION}" --title "Release ${VERSION}" --notes "Release v${VERSION}" --latest
+          gh release create "v${VERSION}" \
+            --title "Release ${VERSION}" \
+            --notes "Release v${VERSION}" \
+            --latest

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,81 +1,76 @@
-name: Auto Release – Ruby SDK
+name: Auto Release – Ruby SDK (Child-B)
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
-    branches: [master]
+    branches:
+      - master
 
 permissions:
   contents: write
 
 jobs:
-  release:
+  check:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
+    outputs:
+      release: ${{ steps.check.outputs.release }}
     steps:
-      # --------------------------------------------
-      # Verify release intent
-      # --------------------------------------------
-      - name: Check release intent
+      - name: Check merge commit for release intent
         id: check
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT }}
           script: |
-            const text = `${context.payload.pull_request.title}
-                          ${context.payload.pull_request.body}`;
-            core.setOutput(
-              'release',
-              /release:\s*yes/i.test(text) ? 'true' : 'false'
-            );
+            const { data: commit } = await github.rest.git.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.pull_request.merge_commit_sha
+            });
+            const msg = commit.message || '';
+            const isRelease = /release:\s*yes/i.test(msg);
+            core.info(`Merge commit message:\n${msg}`);
+            core.info(`Release intent: ${isRelease}`);
+            core.setOutput('release', isRelease ? 'true' : 'false');
 
-      - name: Exit if not release PR
-        if: steps.check.outputs.release == 'false'
-        run: exit 0
-
-      # --------------------------------------------
-      # Checkout merged code
-      # --------------------------------------------
-      - uses: actions/checkout@v4
+  release:
+    needs: check
+    if: needs.check.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    environment: PAT
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
-          fetch-depth: 0
 
-      # --------------------------------------------
-      # Setup Ruby
-      # --------------------------------------------
-      - uses: ruby/setup-ruby@v1
+      - name: Read version from gemspec
+        run: |
+          VERSION=$(ruby -e "spec = Gem::Specification.load('wysiwyg-editor-ruby-sdk.gemspec'); puts spec.version")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
 
-      # --------------------------------------------
-      # Read version
-      # --------------------------------------------
-      - name: Read version
-        run: |
-          VERSION=$(ruby -e "
-            spec = Gem::Specification.load('wysiwyg-editor-ruby-sdk.gemspec')
-            puts spec.version
-          ")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      # --------------------------------------------
-      # Create GitHub Release
-      # --------------------------------------------
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
-        run: |
-          gh release create "v${VERSION}" \
-            --title "Ruby SDK v${VERSION}" \
-            --notes "${{ github.event.pull_request.body }}" \
-         
-      # --------------------------------------------
-      # Build gem
-      # --------------------------------------------
       - name: Build gem
         run: gem build wysiwyg-editor-ruby-sdk.gemspec
 
+      - name: Publish to RubyGems
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          mkdir -p ~/.gem
+          echo ":rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
+          chmod 600 ~/.gem/credentials
+          gem push froala-editor-sdk-${VERSION}.gem
 
-      
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists. Skipping."
+            exit 0
+          fi
+          gh release create "v${VERSION}" --title "Release ${VERSION}" --notes "Release v${VERSION}" --latest

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -70,8 +70,7 @@ jobs:
           gh release create "v${VERSION}" \
             --title "Ruby SDK v${VERSION}" \
             --notes "${{ github.event.pull_request.body }}" \
-            *.gem
-      
+         
       # --------------------------------------------
       # Build gem
       # --------------------------------------------

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -60,14 +60,6 @@ jobs:
           ")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-
-      # --------------------------------------------
-      # Build gem
-      # --------------------------------------------
-      - name: Build gem
-        run: gem build wysiwyg-editor-ruby-sdk.gemspec
-
-
       # --------------------------------------------
       # Create GitHub Release
       # --------------------------------------------
@@ -79,3 +71,12 @@ jobs:
             --title "Ruby SDK v${VERSION}" \
             --notes "${{ github.event.pull_request.body }}" \
             *.gem
+      
+      # --------------------------------------------
+      # Build gem
+      # --------------------------------------------
+      - name: Build gem
+        run: gem build wysiwyg-editor-ruby-sdk.gemspec
+
+
+      

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,81 @@
+name: Auto Release – Ruby SDK
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      # --------------------------------------------
+      # Verify release intent
+      # --------------------------------------------
+      - name: Check release intent
+        id: check
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT }}
+          script: |
+            const text = `${context.payload.pull_request.title}
+                          ${context.payload.pull_request.body}`;
+            core.setOutput(
+              'release',
+              /release:\s*yes/i.test(text) ? 'true' : 'false'
+            );
+
+      - name: Exit if not release PR
+        if: steps.check.outputs.release == 'false'
+        run: exit 0
+
+      # --------------------------------------------
+      # Checkout merged code
+      # --------------------------------------------
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0
+
+      # --------------------------------------------
+      # Setup Ruby
+      # --------------------------------------------
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      # --------------------------------------------
+      # Read version
+      # --------------------------------------------
+      - name: Read version
+        run: |
+          VERSION=$(ruby -e "
+            spec = Gem::Specification.load('wysiwyg-editor-ruby-sdk.gemspec')
+            puts spec.version
+          ")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+
+      # --------------------------------------------
+      # Build gem
+      # --------------------------------------------
+      - name: Build gem
+        run: gem build wysiwyg-editor-ruby-sdk.gemspec
+
+
+      # --------------------------------------------
+      # Create GitHub Release
+      # --------------------------------------------
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "Ruby SDK v${VERSION}" \
+            --notes "${{ github.event.pull_request.body }}" \
+            *.gem

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,0 +1,187 @@
+name: Sync Version – Ruby SDK
+
+on:
+  repository_dispatch:
+    types: [version_update]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      # --------------------------------------------
+      # Checkout repository
+      # --------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0
+
+      # --------------------------------------------
+      # Load & validate incoming version
+      # --------------------------------------------
+      - name: Load & validate version
+        shell: bash
+        run: |
+          set -e
+
+          VERSION="${{ github.event.client_payload.version }}"
+          VERSION="${VERSION//,/\.}"
+
+          if [[ -z "$VERSION" ]]; then
+            echo "❌ Version is missing in repository_dispatch payload"
+            exit 1
+          fi
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "❌ Invalid version format: $VERSION"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "✅ Incoming version validated: $VERSION"
+
+      # --------------------------------------------
+      # Compare current version vs incoming version
+      # --------------------------------------------
+      - name: Compare current version
+        shell: bash
+        run: |
+          set -e
+
+          FILE="lib/froala-editor-sdk/version.rb"
+
+          if [[ ! -f "$FILE" ]]; then
+            echo "❌ version.rb not found at $FILE"
+            exit 1
+          fi
+
+          CURRENT_VERSION=$(ruby -e "
+            load '$FILE'
+            puts [
+              FroalaEditorSDK::Version::Major,
+              FroalaEditorSDK::Version::Minor,
+              FroalaEditorSDK::Version::Tiny
+            ].join('.')
+          ")
+
+          echo "📦 Current version : $CURRENT_VERSION"
+          echo "🚀 Incoming version: $VERSION"
+
+          if [[ "$CURRENT_VERSION" == "${VERSION%%-*}" ]]; then
+            echo "⛔ Versions are identical. Skipping PR creation."
+            exit 0
+          fi
+
+          echo "✅ Versions differ. Proceeding with sync."
+
+      # --------------------------------------------
+      # Prepare release branch
+      # --------------------------------------------
+      - name: Prepare release branch
+        shell: bash
+        run: |
+          set -e
+
+          BRANCH="release-v${VERSION}"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+          git fetch origin
+
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "🔁 Using existing branch: $BRANCH"
+            git checkout "$BRANCH"
+            git pull origin "$BRANCH"
+          else
+            echo "🌱 Creating new branch: $BRANCH"
+            git checkout -b "$BRANCH"
+          fi
+
+      # --------------------------------------------
+      # Update version.rb
+      # --------------------------------------------
+      - name: Update version.rb
+        shell: bash
+        run: |
+          set -e
+
+          FILE="lib/froala-editor-sdk/version.rb"
+
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
+
+          sed -i "s/Major = .*/Major = ${MAJOR}/" "$FILE"
+          sed -i "s/Minor = .*/Minor = ${MINOR}/" "$FILE"
+          sed -i "s/Tiny  = .*/Tiny  = ${PATCH}/" "$FILE"
+
+          echo "✅ Updated version.rb → ${MAJOR}.${MINOR}.${PATCH}"
+
+      # --------------------------------------------
+      # Update gemspec version
+      # --------------------------------------------
+      - name: Update gemspec version
+        shell: bash
+        run: |
+          set -e
+
+          GEMSPEC="wysiwyg-editor-ruby-sdk.gemspec"
+
+          if [[ ! -f "$GEMSPEC" ]]; then
+            echo " Gemspec not found at $GEMSPEC"
+            exit 1
+          fi
+
+          sed -i -E \
+            "s/spec.version\s*=.*/spec.version = '${VERSION}'/" \
+            "$GEMSPEC"
+
+          echo "✅ Updated gemspec version → $VERSION"
+
+      # --------------------------------------------
+      # Commit & push changes
+      # --------------------------------------------
+      - name: Commit & push
+        shell: bash
+        run: |
+          set -e
+
+          git config user.name "froala-travis-bot"
+          git config user.email "froala_git_travis_bot@idera.com"
+
+          git add \
+            lib/froala-editor-sdk/version.rb \
+            wysiwyg-editor-ruby-sdk.gemspec
+
+          if git diff --cached --quiet; then
+            echo "ℹ️ No changes to commit"
+          else
+            git commit -m "chore: release v${VERSION} (Ruby SDK)"
+            git push origin "$BRANCH"
+            echo "🚀 Changes pushed to $BRANCH"
+          fi
+
+      # --------------------------------------------
+      # Create Pull Request (idempotent)
+      # --------------------------------------------
+      - name: Create Pull Request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          set -e
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "✅ Pull request already exists for $BRANCH"
+          else
+            gh pr create \
+              --base master \
+              --head "$BRANCH" \
+              --title "Release v${VERSION} (Ruby SDK)" \
+              --body "release: yes"
+          fi

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,187 +1,102 @@
-name: Sync Version – Ruby SDK
-
+name: Sync Version – Ruby SDK (Child-B)
+ 
 on:
   repository_dispatch:
     types: [version_update]
-
+ 
 permissions:
   contents: write
   pull-requests: write
-
+ 
 jobs:
   sync:
     runs-on: ubuntu-latest
-
+    environment: PAT
+ 
     steps:
-      # --------------------------------------------
-      # Checkout repository
-      # --------------------------------------------
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
-          fetch-depth: 0
+ 
 
-      # --------------------------------------------
-      # Load & validate incoming version
-      # --------------------------------------------
       - name: Load & validate version
-        shell: bash
         run: |
-          set -e
-
           VERSION="${{ github.event.client_payload.version }}"
           VERSION="${VERSION//,/\.}"
-
-          if [[ -z "$VERSION" ]]; then
-            echo "❌ Version is missing in repository_dispatch payload"
+ 
+          if [ -z "$VERSION" ]; then
+            echo "Version missing in dispatch payload"
             exit 1
           fi
-
+ 
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "❌ Invalid version format: $VERSION"
+            echo "Invalid version format: $VERSION"
             exit 1
           fi
+ 
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Dispatching version $VERSION"
 
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-          echo "✅ Incoming version validated: $VERSION"
 
-      # --------------------------------------------
-      # Compare current version vs incoming version
-      # --------------------------------------------
-      - name: Compare current version
-        shell: bash
-        run: |
-          set -e
-
-          FILE="lib/froala-editor-sdk/version.rb"
-
-          if [[ ! -f "$FILE" ]]; then
-            echo "❌ version.rb not found at $FILE"
-            exit 1
-          fi
-
-          CURRENT_VERSION=$(ruby -e "
-            load '$FILE'
-            puts [
-              FroalaEditorSDK::Version::Major,
-              FroalaEditorSDK::Version::Minor,
-              FroalaEditorSDK::Version::Tiny
-            ].join('.')
-          ")
-
-          echo "📦 Current version : $CURRENT_VERSION"
-          echo "🚀 Incoming version: $VERSION"
-
-          if [[ "$CURRENT_VERSION" == "${VERSION%%-*}" ]]; then
-            echo "⛔ Versions are identical. Skipping PR creation."
-            exit 0
-          fi
-
-          echo "✅ Versions differ. Proceeding with sync."
-
-      # --------------------------------------------
-      # Prepare release branch
-      # --------------------------------------------
       - name: Prepare release branch
-        shell: bash
         run: |
-          set -e
-
           BRANCH="release-v${VERSION}"
-          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
           git fetch origin
 
           if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
-            echo "🔁 Using existing branch: $BRANCH"
             git checkout "$BRANCH"
             git pull origin "$BRANCH"
           else
-            echo "🌱 Creating new branch: $BRANCH"
             git checkout -b "$BRANCH"
           fi
 
-      # --------------------------------------------
-      # Update version.rb
-      # --------------------------------------------
       - name: Update version.rb
-        shell: bash
         run: |
-          set -e
-
           FILE="lib/froala-editor-sdk/version.rb"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+ 
+          sed -i "s/Major = .*/Major = ${MAJOR}/" $FILE
+          sed -i "s/Minor = .*/Minor = ${MINOR}/" $FILE
+          sed -i "s/Tiny  = .*/Tiny  = ${PATCH}/" $FILE
+ 
 
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
-
-          sed -i "s/Major = .*/Major = ${MAJOR}/" "$FILE"
-          sed -i "s/Minor = .*/Minor = ${MINOR}/" "$FILE"
-          sed -i "s/Tiny  = .*/Tiny  = ${PATCH}/" "$FILE"
-
-          echo "✅ Updated version.rb → ${MAJOR}.${MINOR}.${PATCH}"
-
-      # --------------------------------------------
-      # Update gemspec version
-      # --------------------------------------------
       - name: Update gemspec version
-        shell: bash
         run: |
-          set -e
-
           GEMSPEC="wysiwyg-editor-ruby-sdk.gemspec"
+          sed -i "s/spec.version *= *.*/spec.version = '${VERSION}'/" $GEMSPEC
+ 
 
-          if [[ ! -f "$GEMSPEC" ]]; then
-            echo " Gemspec not found at $GEMSPEC"
-            exit 1
-          fi
-
-          sed -i -E \
-            "s/spec.version\s*=.*/spec.version = '${VERSION}'/" \
-            "$GEMSPEC"
-
-          echo "✅ Updated gemspec version → $VERSION"
-
-      # --------------------------------------------
-      # Commit & push changes
-      # --------------------------------------------
-      - name: Commit & push
-        shell: bash
+      - name: Commit changes
         run: |
-          set -e
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+ 
+          git add lib/froala-editor-sdk/version.rb wysiwyg-editor-ruby-sdk.gemspec release_notes.txt
+ 
+          git commit -m "chore: release v${VERSION} (Ruby SDK)" || echo "Nothing to commit"
+          git push origin "$BRANCH"
+ 
 
-          git config user.name "froala-travis-bot"
-          git config user.email "froala_git_travis_bot@idera.com"
-
-          git add \
-            lib/froala-editor-sdk/version.rb \
-            wysiwyg-editor-ruby-sdk.gemspec
-
-          if git diff --cached --quiet; then
-            echo "ℹ️ No changes to commit"
-          else
-            git commit -m "chore: release v${VERSION} (Ruby SDK)"
-            git push origin "$BRANCH"
-            echo "🚀 Changes pushed to $BRANCH"
-          fi
-
-      # --------------------------------------------
-      # Create Pull Request (idempotent)
-      # --------------------------------------------
       - name: Create Pull Request
-        shell: bash
         env:
           GH_TOKEN: ${{ secrets.PAT }}
+          RELEASE_NOTES: ${{ github.event.client_payload.release_notes }}
         run: |
-          set -e
+          git fetch origin master
 
-          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
-            echo "✅ Pull request already exists for $BRANCH"
-          else
-            gh pr create \
-              --base master \
-              --head "$BRANCH" \
-              --title "Release v${VERSION} (Ruby SDK)" \
-              --body "release: yes"
+          if git diff --quiet origin/master..."$BRANCH"; then
+            echo "No commits between $BRANCH and master. Skipping PR creation."
+            exit 0
           fi
+
+          PR_BODY=$(printf "## Release Notes (from primary repo)\n\n%s\n\n---\n_To publish this release, add \`release: yes\` to the merge commit message when merging._\n" "$RELEASE_NOTES")
+
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "Release v${VERSION}" \
+            --body "$PR_BODY" \
+            || echo "Pull request already exists"

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,51 +1,47 @@
 name: Sync Version – Ruby SDK
- 
+
 on:
   repository_dispatch:
     types: [version_update]
- 
+
 permissions:
   contents: write
   pull-requests: write
- 
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     environment: PAT
- 
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
- 
 
       - name: Load & validate version
         run: |
           VERSION="${{ github.event.client_payload.version }}"
           VERSION="${VERSION//,/\.}"
- 
+
           if [ -z "$VERSION" ]; then
             echo "Version missing in dispatch payload"
             exit 1
           fi
- 
+
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid version format: $VERSION"
             exit 1
           fi
- 
+
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Dispatching version $VERSION"
-
 
       - name: Prepare release branch
         run: |
           BRANCH="release-v${VERSION}"
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-
           git fetch origin
-
           if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
             git checkout "$BRANCH"
             git pull origin "$BRANCH"
@@ -57,28 +53,25 @@ jobs:
         run: |
           FILE="lib/froala-editor-sdk/version.rb"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
- 
+
           sed -i "s/Major = .*/Major = ${MAJOR}/" $FILE
           sed -i "s/Minor = .*/Minor = ${MINOR}/" $FILE
           sed -i "s/Tiny  = .*/Tiny  = ${PATCH}/" $FILE
- 
 
       - name: Update gemspec version
         run: |
           GEMSPEC="wysiwyg-editor-ruby-sdk.gemspec"
           sed -i "s/spec.version *= *.*/spec.version = '${VERSION}'/" $GEMSPEC
- 
 
       - name: Commit changes
         run: |
-         git config user.name "froala-travis-bot"
-         git config user.email "froala_git_travis_bot@idera.com"
- 
-          git add lib/froala-editor-sdk/version.rb wysiwyg-editor-ruby-sdk.gemspec release_notes.txt
- 
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          git add lib/froala-editor-sdk/version.rb wysiwyg-editor-ruby-sdk.gemspec
+
           git commit -m "chore: release v${VERSION} (Ruby SDK)" || echo "Nothing to commit"
           git push origin "$BRANCH"
- 
 
       - name: Create Pull Request
         env:
@@ -86,14 +79,11 @@ jobs:
           RELEASE_NOTES: ${{ github.event.client_payload.release_notes }}
         run: |
           git fetch origin master
-
           if git diff --quiet origin/master..."$BRANCH"; then
             echo "No commits between $BRANCH and master. Skipping PR creation."
             exit 0
           fi
-
-          PR_BODY=$(printf "## Release Notes (from primary repo)\n\n%s\n\n---\n_To publish this release, add \`release: yes\` to the merge commit message when merging._\n" "$RELEASE_NOTES")
-
+          PR_BODY=$(printf "## Release Notes (from primary repo)\n\n%s\n" "$RELEASE_NOTES")
           gh pr create \
             --base master \
             --head "$BRANCH" \

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,4 +1,4 @@
-name: Sync Version – Ruby SDK (Child-B)
+name: Sync Version – Ruby SDK
  
 on:
   repository_dispatch:
@@ -71,8 +71,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+         git config user.name "froala-travis-bot"
+         git config user.email "froala_git_travis_bot@idera.com"
  
           git add lib/froala-editor-sdk/version.rb wysiwyg-editor-ruby-sdk.gemspec release_notes.txt
  


### PR DESCRIPTION
- Fixed a typo — workflow was checking a step name that didn't exist, so the guard never worked
- Split the workflow into two jobs so skipping actually stops everything, not just one step
- Removed release: yes from the PR description so it doesn't sneak into the commit on its own
